### PR TITLE
mp4 file extension chaged to .m4a extension

### DIFF
--- a/internal/app/downloader.go
+++ b/internal/app/downloader.go
@@ -48,7 +48,7 @@ func (d *downloader) Download(ctx context.Context, track *domain.Track, destPath
 		ext := constants.ExtFLAC
 		switch mimeType {
 		case constants.MimeTypeMP4:
-			ext = constants.ExtMP4
+			ext = constants.ExtM4A
 		case constants.MimeTypeMP3:
 			ext = constants.ExtMP3
 		}


### PR DESCRIPTION
<img width="722" height="265" alt="image" src="https://github.com/user-attachments/assets/58a79e5b-ed4f-4266-a457-4d91d03de149" />

Current .mp4 files are .m4a audio-only files. 
.mp4 files are not compatible with Navidrome, but .m4a files are.