### PR TITLE
fix(catalog): handle provider search 403

### DIFF
--- a/internal/catalog/hifi.go
+++ b/internal/catalog/hifi.go
@@ -20,6 +20,8 @@ type HifiProvider struct {
 	BaseURL string
 }
 
+const defaultProviderUserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+
 func NewHifiProvider(baseURL string) *HifiProvider {
 	return &HifiProvider{
 		BaseURL: baseURL,
@@ -27,6 +29,20 @@ func NewHifiProvider(baseURL string) *HifiProvider {
 			Timeout: 20 * time.Second,
 		}, 500*time.Millisecond),
 	}
+}
+
+func (p *HifiProvider) setRequestHeaders(req *http.Request) {
+	if req.Header.Get("User-Agent") == "" {
+		req.Header.Set("User-Agent", defaultProviderUserAgent)
+	}
+	if req.Header.Get("Accept") == "" {
+		req.Header.Set("Accept", "application/json, text/plain, */*")
+	}
+	if req.Header.Get("Accept-Language") == "" {
+		req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+	}
+	req.Header.Set("Referer", "https://listen.tidal.com/")
+	req.Header.Set("Origin", "https://listen.tidal.com")
 }
 
 func (p *HifiProvider) ensureAbsoluteURL(urlOrID string, size ...string) string {
@@ -127,6 +143,7 @@ func (p *HifiProvider) GetStream(ctx context.Context, trackID string, quality st
 		if err != nil {
 			return nil, "", err
 		}
+		p.setRequestHeaders(req)
 		sResp, err := p.client.Do(ctx, req)
 		if err != nil {
 			return nil, "", err
@@ -165,6 +182,7 @@ func (p *HifiProvider) GetStream(ctx context.Context, trackID string, quality st
 		if err != nil {
 			return nil, "", err
 		}
+		p.setRequestHeaders(req)
 		sResp, err := p.client.Do(ctx, req)
 		if err != nil {
 			return nil, "", err
@@ -278,6 +296,7 @@ func (p *HifiProvider) get(ctx context.Context, url string, target interface{}) 
 	if err != nil {
 		return err
 	}
+	p.setRequestHeaders(req)
 
 	resp, err := p.client.Do(ctx, req)
 	if err != nil {

--- a/internal/catalog/search.go
+++ b/internal/catalog/search.go
@@ -18,29 +18,34 @@ func (p *HifiProvider) Search(ctx context.Context, query string, searchType stri
 	switch searchType {
 	case "artist":
 		artists, err := p.searchArtists(ctx, query)
-		if err == nil {
-			res.Artists = artists
+		if err != nil {
+			return nil, err
 		}
+		res.Artists = artists
 	case "album":
 		albums, err := p.searchAlbums(ctx, query)
-		if err == nil {
-			res.Albums = albums
+		if err != nil {
+			return nil, err
 		}
+		res.Albums = albums
 	case "track":
 		tracks, err := p.searchTracks(ctx, query)
-		if err == nil {
-			res.Tracks = tracks
+		if err != nil {
+			return nil, err
 		}
+		res.Tracks = tracks
 	case "playlist":
 		playlists, err := p.searchPlaylists(ctx, query)
-		if err == nil {
-			res.Playlists = playlists
+		if err != nil {
+			return nil, err
 		}
+		res.Playlists = playlists
 	default:
 		albums, err := p.searchAlbums(ctx, query)
-		if err == nil {
-			res.Albums = albums
+		if err != nil {
+			return nil, err
 		}
+		res.Albums = albums
 	}
 
 	return res, nil

--- a/internal/catalog/search_test.go
+++ b/internal/catalog/search_test.go
@@ -1,0 +1,35 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHifiProviderSearch_ReturnsErrorOnUpstreamFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream failure", http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	provider := NewHifiProvider(srv.URL)
+	types := []string{"artist", "album", "track", "playlist", "unexpected"}
+
+	for _, searchType := range types {
+		t.Run(searchType, func(t *testing.T) {
+			res, err := provider.Search(context.Background(), "test", searchType)
+			if err == nil {
+				t.Fatalf("expected error for search type %q, got nil", searchType)
+			}
+			if res != nil {
+				t.Fatalf("expected nil result on error for search type %q", searchType)
+			}
+			if !strings.Contains(err.Error(), fmt.Sprintf("API request failed: %d", http.StatusBadGateway)) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Return search errors instead of empty results so fallback can try next provider and UI can show real failures.

Set browser-like request headers for provider API calls because some mirrors block default Go User-Agent with 403.

Add regression test for upstream error propagation.

Upgrade Note (existing deployments)
If your instance previously cached empty search responses, you may still see No results found after upgrading.
Run this one-time cache cleanup:

```
# Stop app (release DB handle)
docker compose stop navidrums

# Clear cached search entries
docker run --rm --user 0:0 -v "${PWD}\data:/data:rw" keinos/sqlite3 sqlite3 /data/navidrums.db "DELETE FROM cache WHERE key LIKE 'search:%';"

# Verify cache cleared (expect 0)
docker run --rm --user 0:0 -v "${PWD}\data:/data:rw" keinos/sqlite3 sqlite3 /data/navidrums.db "SELECT COUNT(*) FROM cache WHERE key LIKE 'search:%';"

# Start app
docker compose start navidrums

# Verify endpoint
curl.exe -i "http://localhost:5236/htmx/search?q=witness&type=album"
```

This pull request was prepared with assistance from GitHub Copilot (GPT-5.3-Codex).